### PR TITLE
raft_topology: fence RPCs when transitioning to tokens_state::read_write

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1153,6 +1153,7 @@ idls = ['idl/gossip_digest.idl.hh',
         'idl/per_partition_rate_limit_info.idl.hh',
         'idl/position_in_partition.idl.hh',
         'idl/experimental/broadcast_tables_lang.idl.hh',
+        'idl/storage_service.idl.hh',
         ]
 
 rusts = [

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -17,6 +17,7 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/json/json_elements.hh>
+#include "mutation_partition_visitor.hh"
 #include "system_keyspace.hh"
 #include "types.hh"
 #include "service/storage_proxy.hh"
@@ -184,6 +185,27 @@ schema_ptr system_keyspace::batchlog() {
        return builder.build(schema_builder::compact_storage::no);
     }();
     return paxos;
+}
+
+schema_ptr system_keyspace::topology_changes() {
+    static thread_local auto schema = [] {
+        auto id = generate_legacy_id(NAME, TOPOLOGY_CHANGES);
+        return schema_builder(NAME, TOPOLOGY_CHANGES, std::optional(id))
+            .with_column("raft_id", uuid_type, column_kind::partition_key)
+            .with_column("datacenter", utf8_type)
+            .with_column("rack", utf8_type)
+            .with_column("tokens", set_type_impl::get_instance(utf8_type, true))
+            .with_column("tokens_state", utf8_type)
+            .with_column("node_state", utf8_type)
+            .with_column("release_version", utf8_type)
+            .with_column("topology_request", utf8_type)
+            .set_comment("Current state of topology change machine")
+            .with_version(generate_schema_version(id))
+            .set_wait_for_sync_to_commitlog(true)
+            .with_null_sharder()
+            .build();
+    }();
+    return schema;
 }
 
 schema_ptr system_keyspace::raft() {
@@ -2687,7 +2709,7 @@ std::vector<schema_ptr> system_keyspace::all_tables(const db::config& cfg) {
                     v3::cdc_local(),
     });
     if (cfg.check_experimental(db::experimental_features_t::feature::RAFT)) {
-        r.insert(r.end(), {raft(), raft_snapshots(), raft_config(), group0_history(), discovery()});
+        r.insert(r.end(), {raft(), raft_snapshots(), raft_config(), group0_history(), discovery(), topology_changes()});
 
         if (cfg.check_experimental(db::experimental_features_t::feature::BROADCAST_TABLES)) {
             r.insert(r.end(), {broadcast_kv_store()});
@@ -3312,6 +3334,155 @@ future<> system_keyspace::save_group0_upgrade_state(service::group0_upgrade_stat
     }();
 
     return set_scylla_local_param(GROUP0_UPGRADE_STATE_KEY, value);
+}
+
+future<service::topology_change_sm::topology_type> system_keyspace::load_topology_state() {
+    auto rs = co_await qctx->execute_cql(
+        format("SELECT * FROM system.{}", TOPOLOGY_CHANGES));
+    assert(rs);
+
+    auto ret = make_lw_shared<service::topology_change_sm::topology_type::element_type>();
+
+    if (rs->empty()) {
+        co_return ret;
+    }
+
+    for (auto& row : *rs) {
+        auto raft_id = row.get_as<utils::UUID>("raft_id");
+        auto datacenter = row.get_as<sstring>("datacenter");
+        auto rack = row.get_as<sstring>("rack");
+        auto release_version = row.get_as<sstring>("release_version");
+        auto node_state = row.get_as<sstring>("node_state");
+
+        service::node_state nstate;
+        if (node_state == "bootstrapping") {
+            nstate = service::node_state::bootstrapping;
+        } else if (node_state == "normal") {
+            nstate = service::node_state::normal;
+        }else if (node_state == "unbootstrapping") {
+            nstate = service::node_state::unbootstrapping;
+        } else if (node_state == "left") {
+            nstate = service::node_state::left;
+        } else if (node_state == "removing") {
+            nstate = service::node_state::removing;
+        } else if (node_state == "replacing") {
+            nstate = service::node_state::replacing;
+        } else if (node_state == "requesting") {
+            nstate = service::node_state::requesting;
+        } else {
+            assert(false);
+        }
+
+        std::optional<service::tokens_state> tstate;
+        if (row.has("tokens_state")) {
+            auto tokens_state = row.get_as<sstring>("tokens_state");
+
+            if (tokens_state == "write only") {
+                tstate = service::tokens_state::write_only;
+            } else if (tokens_state == "read write") {
+                tstate = service::tokens_state::read_write;
+            } else if (tokens_state == "owner") {
+                tstate = service::tokens_state::owner;
+            } else {
+                assert(false);
+            }
+        }
+
+        std::unordered_set<dht::token> t;
+
+        if (row.has("tokens")) {
+            auto blob = row.get_blob("tokens");
+            auto cdef = topology_changes()->get_column_definition("tokens");
+            auto deserialized = cdef->type->deserialize(blob);
+            auto tokens = value_cast<set_type_impl::native_type>(deserialized);
+            t = decode_tokens(tokens);
+        }
+
+        std::optional<rjson::value> req;
+
+        if (row.has("topology_request")) {
+            auto val = row.get_as<sstring>("topology_request");
+            try {
+                req = rjson::parse(val);
+            } catch (rjson::error& err) {
+                slogger.error("Error while loading topology request '{}'. It will be ignored: {}", val, err);
+            }
+        }
+
+        // there cannot be tokens without state
+        assert(tstate || t.size() == 0);
+
+        ret->emplace(raft_id, service::replica_state{nstate, std::move(datacenter), std::move(rack), std::move(release_version), std::move(req),
+            tstate ? std::optional<service::replica_state::ring_state>(service::replica_state::ring_state{*tstate, std::move(t)}) : std::nullopt});
+    }
+
+    co_return ret;
+}
+
+mutation system_keyspace::make_topology_change_state_mutation(int64_t ts, raft::server_id raft_id, service::node_state state, sstring datacenter,
+         sstring rack, sstring release_version, const std::optional<rjson::value>& request, const std::unordered_set<dht::token>& tokens, std::optional<service::tokens_state> tokens_state) {
+    // there cannot be tokens without state
+    assert(tokens_state || tokens.size() == 0);
+    auto s = topology_changes();
+    mutation m(s, partition_key::from_singular(*s, raft_id.uuid()));
+    auto& row = m.partition().clustered_row(*s, clustering_key::make_empty());
+    row.apply(row_marker(ts));
+
+    auto cdef = s->get_column_definition("datacenter");
+    assert(cdef);
+    row.cells().apply(*cdef, atomic_cell::make_live(*cdef->type, ts, cdef->type->decompose(datacenter)));
+
+    auto cdef2 = s->get_column_definition("rack");
+    assert(cdef2);
+    row.cells().apply(*cdef2, atomic_cell::make_live(*cdef2->type, ts, cdef2->type->decompose(rack)));
+
+    auto cdef3 = s->get_column_definition("tokens_state");
+    assert(cdef3);
+    if (tokens_state) {
+        sstring tstate = fmt::format("{}", *tokens_state);
+        row.cells().apply(*cdef3, atomic_cell::make_live(*cdef3->type, ts, cdef3->type->decompose(tstate)));
+    } else {
+        row.cells().apply(*cdef3, atomic_cell::make_dead(ts, gc_clock::now()));
+    }
+
+    auto cdef4 = s->get_column_definition("tokens");
+    assert(cdef4);
+    collection_mutation_description cm;
+    if (tokens.size()) {
+        auto vtype = static_pointer_cast<const set_type_impl>(cdef4->type)->get_elements_type();
+
+        cm.cells.reserve(tokens.size());
+
+        auto t = prepare_tokens(tokens);
+        for (auto&& value : t) {
+            cm.cells.emplace_back(vtype->decompose(value), atomic_cell::make_live(*bytes_type, ts, bytes_view()));
+        }
+
+        row.cells().apply(*cdef4, cm.serialize(*cdef4->type));
+    } else {
+        cm.tomb = tombstone{ts, gc_clock::now()};
+        row.cells().apply(*cdef4, cm.serialize(*cdef4->type));
+    }
+
+    sstring nstate = fmt::format("{}", state);
+    auto cdef6 = s->get_column_definition("node_state");
+    assert(cdef6);
+    row.cells().apply(*cdef6, atomic_cell::make_live(*cdef6->type, ts, cdef6->type->decompose(nstate)));
+
+    auto cdef7 = s->get_column_definition("release_version");
+    assert(cdef7);
+    row.cells().apply(*cdef7, atomic_cell::make_live(*cdef7->type, ts, cdef7->type->decompose(release_version)));
+
+    auto cdef8 = s->get_column_definition("topology_request");
+    assert(cdef8);
+    if (request) {
+        sstring val = fmt::format("{}", *request);
+        row.cells().apply(*cdef8, atomic_cell::make_live(*cdef3->type, ts, cdef3->type->decompose(val)));
+    } else {
+        row.cells().apply(*cdef8, atomic_cell::make_dead(ts, gc_clock::now()));
+    }
+
+    return m;
 }
 
 sstring system_keyspace_name() {

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -27,6 +27,7 @@
 #include "locator/host_id.hh"
 #include "service/raft/group0_fwd.hh"
 #include "tasks/task_manager.hh"
+#include "service/topology_change_sm.hh"
 
 namespace service {
 
@@ -140,6 +141,7 @@ public:
     static constexpr auto GROUP0_HISTORY = "group0_history";
     static constexpr auto DISCOVERY = "discovery";
     static constexpr auto BROADCAST_KV_STORE = "broadcast_kv_store";
+    static constexpr auto TOPOLOGY_CHANGES = "topology_changes";
 
     struct v3 {
         static constexpr auto BATCHES = "batches";
@@ -224,6 +226,7 @@ public:
     static schema_ptr group0_history();
     static schema_ptr discovery();
     static schema_ptr broadcast_kv_store();
+    static schema_ptr topology_changes();
 
     static table_schema_version generate_schema_version(table_id table_id, uint16_t offset = 0);
 
@@ -440,6 +443,11 @@ public:
     // Checks whether the group 0 history table contains the given state ID.
     // Assumes that the history table exists, i.e. Raft experimental feature is enabled.
     static future<bool> group0_history_contains(utils::UUID state_id);
+
+    static future<service::topology_change_sm::topology_type> load_topology_state();
+    mutation make_topology_change_state_mutation(int64_t ts, raft::server_id raft_id, service::node_state state, sstring datacenter,
+         sstring rack, sstring release_version, const std::optional<rjson::value>&,
+         const std::unordered_set<dht::token>& tokens, std::optional<service::tokens_state> tokens_state);
 
     // The mutation appends the given state ID to the group 0 history table, with the given description if non-empty.
     //

--- a/dht/boot_strapper.cc
+++ b/dht/boot_strapper.cc
@@ -63,6 +63,21 @@ future<> boot_strapper::bootstrap(streaming::stream_reason reason, gms::gossiper
     }
 }
 
+std::unordered_set<token> boot_strapper::get_random_bootstrap_tokens(const token_metadata_ptr tmptr, const db::config& cfg, dht::check_token_endpoint check) {
+    size_t num_tokens = cfg.num_tokens();
+    if (num_tokens < 1) {
+        throw std::runtime_error("num_tokens must be >= 1");
+    }
+
+    if (num_tokens == 1) {
+        blogger.warn("Picking random token for a single vnode.  You should probably add more vnodes; failing that, you should probably specify the token manually");
+    }
+
+    auto tokens = get_random_tokens(std::move(tmptr), num_tokens);
+    blogger.info("Get random bootstrap_tokens={}", tokens);
+    return tokens;
+}
+
 std::unordered_set<token> boot_strapper::get_bootstrap_tokens(const token_metadata_ptr tmptr, const db::config& cfg, dht::check_token_endpoint check) {
     std::unordered_set<sstring> initial_tokens;
     sstring tokens_string = cfg.initial_token();
@@ -87,19 +102,7 @@ std::unordered_set<token> boot_strapper::get_bootstrap_tokens(const token_metada
         blogger.info("Get manually specified bootstrap_tokens={}", tokens);
         return tokens;
     }
-
-    size_t num_tokens = cfg.num_tokens();
-    if (num_tokens < 1) {
-        throw std::runtime_error("num_tokens must be >= 1");
-    }
-
-    if (num_tokens == 1) {
-        blogger.warn("Picking random token for a single vnode.  You should probably add more vnodes; failing that, you should probably specify the token manually");
-    }
-
-    auto tokens = get_random_tokens(std::move(tmptr), num_tokens);
-    blogger.info("Get random bootstrap_tokens={}", tokens);
-    return tokens;
+    return get_random_bootstrap_tokens(tmptr, cfg, check);
 }
 
 std::unordered_set<token> boot_strapper::get_random_tokens(const token_metadata_ptr tmptr, size_t num_tokens) {

--- a/dht/boot_strapper.hh
+++ b/dht/boot_strapper.hh
@@ -61,6 +61,11 @@ public:
      */
     static std::unordered_set<token> get_bootstrap_tokens(const token_metadata_ptr tmptr, const db::config& cfg, check_token_endpoint check);
 
+    /**
+     * Same as above but does not consult initialtoken config
+     */
+    static std::unordered_set<token> get_random_bootstrap_tokens(const token_metadata_ptr tmptr, const db::config& cfg, check_token_endpoint check);
+
     static std::unordered_set<token> get_random_tokens(const token_metadata_ptr tmptr, size_t num_tokens);
 #if 0
     public static class StringSerializer implements IVersionedSerializer<String>

--- a/idl/group0_state_machine.idl.hh
+++ b/idl/group0_state_machine.idl.hh
@@ -23,8 +23,12 @@ struct broadcast_table_query {
     service::broadcast_tables::query query;
 };
 
+struct topology_change {
+    std::vector<canonical_mutation> mutations;
+};
+
 struct group0_command {
-    std::variant<service::schema_change, service::broadcast_table_query> change;
+    std::variant<service::schema_change, service::broadcast_table_query, service::topology_change> change;
     canonical_mutation history_append;
 
     std::optional<utils::UUID> prev_state_id;

--- a/idl/replica_exception.idl.hh
+++ b/idl/replica_exception.idl.hh
@@ -15,10 +15,16 @@ struct no_exception {};
 class rate_limit_exception {
 };
 
+class stale_topology_exception {
+    int64_t caller_version();
+    int64_t callee_version();
+};
+
 struct exception_variant {
     std::variant<replica::unknown_exception,
             replica::no_exception,
-            replica::rate_limit_exception
+            replica::rate_limit_exception,
+            replica::stale_topology_exception
     > reason;
 };
 

--- a/idl/storage_proxy.idl.hh
+++ b/idl/storage_proxy.idl.hh
@@ -22,16 +22,22 @@
 #include "idl/keys.idl.hh"
 #include "idl/uuid.idl.hh"
 
-verb [[with_client_info, with_timeout, one_way]] mutation (frozen_mutation fm, inet_address_vector_replica_set forward, gms::inet_address reply_to, unsigned shard, uint64_t response_id, std::optional<tracing::trace_info> trace_info [[version 1.3.0]], db::per_partition_rate_limit::info rate_limit_info [[version 5.1.0]]);
+namespace service {
+    struct fencing_token {
+        int64_t topology_version;
+    };
+}
+
+verb [[with_client_info, with_timeout, one_way]] mutation (frozen_mutation fm, inet_address_vector_replica_set forward, gms::inet_address reply_to, unsigned shard, uint64_t response_id, std::optional<tracing::trace_info> trace_info [[version 1.3.0]], db::per_partition_rate_limit::info rate_limit_info [[version 5.1.0]], service::fencing_token fence [[version 5.2.0]]);
 verb [[with_client_info, one_way]] mutation_done (unsigned shard, uint64_t response_id, db::view::update_backlog backlog [[version 3.1.0]]);
 verb [[with_client_info, one_way]] mutation_failed (unsigned shard, uint64_t response_id, size_t num_failed, db::view::update_backlog backlog [[version 3.1.0]], replica::exception_variant exception [[version 5.1.0]]);
-verb [[with_client_info, with_timeout]] counter_mutation (std::vector<frozen_mutation> fms, db::consistency_level cl, std::optional<tracing::trace_info> trace_info);
-verb [[with_client_info, with_timeout, one_way]] hint_mutation (frozen_mutation fm, inet_address_vector_replica_set forward, gms::inet_address reply_to, unsigned shard, uint64_t response_id, std::optional<tracing::trace_info> trace_info [[version 1.3.0]] /* this verb was mistakenly introduced with optional trace_info */);
-verb [[with_client_info, with_timeout]] read_data (query::read_command cmd, ::compat::wrapping_partition_range pr, query::digest_algorithm digest [[version 3.0.0]], db::per_partition_rate_limit::info rate_limit_info [[version 5.1.0]]) -> query::result [[lw_shared_ptr]], cache_temperature [[version 2.0.0]], replica::exception_variant [[version 5.1.0]];
-verb [[with_client_info, with_timeout]] read_mutation_data (query::read_command cmd, ::compat::wrapping_partition_range pr) -> reconcilable_result [[lw_shared_ptr]], cache_temperature [[version 2.0.0]], replica::exception_variant [[version 5.1.0]];
-verb [[with_client_info, with_timeout]] read_digest (query::read_command cmd, ::compat::wrapping_partition_range pr, query::digest_algorithm digest [[version 3.0.0]], db::per_partition_rate_limit::info rate_limit_info [[version 5.1.0]]) -> query::result_digest, api::timestamp_type [[version 1.2.0]], cache_temperature [[version 2.0.0]], replica::exception_variant [[version 5.1.0]], std::optional<full_position> [[version 5.2.0]];
+verb [[with_client_info, with_timeout]] counter_mutation (std::vector<frozen_mutation> fms, db::consistency_level cl, std::optional<tracing::trace_info> trace_info, service::fencing_token fence [[version 5.2.0]]);
+verb [[with_client_info, with_timeout, one_way]] hint_mutation (frozen_mutation fm, inet_address_vector_replica_set forward, gms::inet_address reply_to, unsigned shard, uint64_t response_id, std::optional<tracing::trace_info> trace_info [[version 1.3.0]] /* this verb was mistakenly introduced with optional trace_info */, service::fencing_token fence [[version 5.2.0]]);
+verb [[with_client_info, with_timeout]] read_data (query::read_command cmd, ::compat::wrapping_partition_range pr, query::digest_algorithm digest [[version 3.0.0]], db::per_partition_rate_limit::info rate_limit_info [[version 5.1.0]], service::fencing_token fence [[version 5.2.0]]) -> query::result [[lw_shared_ptr]], cache_temperature [[version 2.0.0]], replica::exception_variant [[version 5.1.0]];
+verb [[with_client_info, with_timeout]] read_mutation_data (query::read_command cmd, ::compat::wrapping_partition_range pr, service::fencing_token fence [[version 5.2.0]]) -> reconcilable_result [[lw_shared_ptr]], cache_temperature [[version 2.0.0]], replica::exception_variant [[version 5.1.0]];
+verb [[with_client_info, with_timeout]] read_digest (query::read_command cmd, ::compat::wrapping_partition_range pr, query::digest_algorithm digest [[version 3.0.0]], db::per_partition_rate_limit::info rate_limit_info [[version 5.1.0]], service::fencing_token fence [[version 5.2.0]]) -> query::result_digest, api::timestamp_type [[version 1.2.0]], cache_temperature [[version 2.0.0]], replica::exception_variant [[version 5.1.0]], std::optional<full_position> [[version 5.2.0]];
 verb [[with_timeout]] truncate (sstring, sstring);
 verb [[with_client_info, with_timeout]] paxos_prepare (query::read_command cmd, partition_key key, utils::UUID ballot, bool only_digest, query::digest_algorithm da, std::optional<tracing::trace_info> trace_info) -> service::paxos::prepare_response [[unique_ptr]];
 verb [[with_client_info, with_timeout]] paxos_accept (service::paxos::proposal proposal [[ref]], std::optional<tracing::trace_info> trace_info) -> bool;
-verb [[with_client_info, with_timeout, one_way]] paxos_learn (service::paxos::proposal decision, inet_address_vector_replica_set forward, gms::inet_address reply_to, unsigned shard, uint64_t response_id, std::optional<tracing::trace_info>);
+verb [[with_client_info, with_timeout, one_way]] paxos_learn (service::paxos::proposal decision, inet_address_vector_replica_set forward, gms::inet_address reply_to, unsigned shard, uint64_t response_id, std::optional<tracing::trace_info>, service::fencing_token fence [[version 5.2.0]]);
 verb [[with_client_info, with_timeout, one_way]] paxos_prune (table_schema_version schema_id, partition_key key [[ref]], utils::UUID ballot, std::optional<tracing::trace_info> trace_info);

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace service {
+  struct raft_bootstrap_cmd {
+      enum class command: uint8_t {
+          barrier,
+          stream_ranges,
+          fence_old_reads
+      };
+      service::raft_bootstrap_cmd::command cmd;
+  };
+
+  struct raft_bootstrap_cmd_result {
+      enum class command_status: uint8_t {
+          fail,
+          success
+      };
+      service::raft_bootstrap_cmd_result::command_status status;
+  };
+
+  verb raft_bootstrap_cmd (service::raft_bootstrap_cmd) -> service::raft_bootstrap_cmd_result;
+}

--- a/main.cc
+++ b/main.cc
@@ -1442,7 +1442,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             service::raft_group0 group0_service{
                     stop_signal.as_local_abort_source(), raft_gr.local(), messaging.local(),
-                    gossiper.local(), qp.local(), mm.local(), feature_service.local(), sys_ks.local(), group0_client};
+                    gossiper.local(), qp.local(), mm.local(), feature_service.local(), sys_ks.local(), group0_client, ss.local()};
             auto stop_group0_service = defer_verbose_shutdown("group 0 service", [&group0_service] {
                 group0_service.abort().get();
             });

--- a/main.cc
+++ b/main.cc
@@ -1380,7 +1380,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             supervisor::notify("starting storage service", true);
-            ss.local().init_messaging_service_part().get();
+            ss.local().init_messaging_service_part(sys_dist_ks).get();
             auto stop_ss_msg = defer_verbose_shutdown("storage service messaging", [&ss] {
                 ss.local().uninit_messaging_service_part().get();
             });

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -41,6 +41,7 @@
 #include "cache_temperature.hh"
 #include "raft/raft.hh"
 #include "service/raft/group0_fwd.hh"
+#include "service/raft_bootstrap.hh"
 #include "replica/exceptions.hh"
 #include "serializer.hh"
 #include "full_position.hh"

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -45,6 +45,7 @@
 #include "serializer.hh"
 #include "full_position.hh"
 #include "db/per_partition_rate_limit_info.hh"
+#include "service/raft_bootstrap.hh"
 #include "idl/consistency_level.dist.hh"
 #include "idl/tracing.dist.hh"
 #include "idl/result.dist.hh"
@@ -73,6 +74,7 @@
 #include "idl/replica_exception.dist.hh"
 #include "idl/per_partition_rate_limit_info.dist.hh"
 #include "idl/storage_proxy.dist.hh"
+#include "idl/storage_service.dist.hh"
 #include "message/rpc_protocol_impl.hh"
 #include "idl/consistency_level.dist.impl.hh"
 #include "idl/tracing.dist.impl.hh"
@@ -113,6 +115,7 @@
 #include "idl/partition_checksum.dist.impl.hh"
 #include "idl/forward_request.dist.hh"
 #include "idl/forward_request.dist.impl.hh"
+#include "idl/storage_service.dist.impl.hh"
 
 namespace netw {
 
@@ -508,6 +511,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::GROUP0_PEER_EXCHANGE:
     case messaging_verb::GROUP0_MODIFY_CONFIG:
     case messaging_verb::GET_GROUP0_UPGRADE_STATE:
+    case messaging_verb::RAFT_BOOTSTRAP_CMD:
         // See comment above `TOPOLOGY_INDEPENDENT_IDX`.
         // DO NOT put any 'hot' (e.g. data path) verbs in this group,
         // only verbs which are 'rare' and 'cheap'.

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -180,7 +180,8 @@ enum class messaging_verb : int32_t {
     FORWARD_REQUEST = 61,
     GET_GROUP0_UPGRADE_STATE = 62,
     DIRECT_FD_PING = 63,
-    LAST = 64,
+    RAFT_BOOTSTRAP_CMD = 64,
+    LAST = 65,
 };
 
 } // namespace netw

--- a/replica/exceptions.cc
+++ b/replica/exceptions.cc
@@ -20,8 +20,10 @@ namespace replica {
 exception_variant try_encode_replica_exception(std::exception_ptr eptr) {
     try {
         std::rethrow_exception(std::move(eptr));
-    } catch (rate_limit_exception&) {
+    } catch (const rate_limit_exception&) {
         return rate_limit_exception();
+    } catch (const stale_topology_exception& e) {
+        return e;
     } catch (...) {
         return no_exception{};
     }

--- a/replica/exceptions.hh
+++ b/replica/exceptions.hh
@@ -18,6 +18,7 @@
 
 #include "utils/exception_container.hh"
 #include "utils/result.hh"
+#include "seastarx.hh"
 
 namespace replica {
 
@@ -43,10 +44,34 @@ public:
     virtual const char* what() const noexcept override { return "rate limit exceeded"; }
 };
 
+class stale_topology_exception final : public replica_exception {
+    int64_t _caller_version;
+    int64_t _callee_version;
+    sstring _message;
+public:
+    stale_topology_exception(int64_t caller_version, int64_t callee_version)
+        : _caller_version(caller_version)
+        , _callee_version(callee_version)
+        , _message(format("stale topology exception, caller version {}, callee version {}", caller_version, callee_version))
+    {
+    }
+
+    int64_t caller_version() const {
+        return _caller_version;
+    }
+
+    int64_t callee_version() const {
+        return _callee_version;
+    }
+
+    virtual const char* what() const noexcept override { return _message.c_str(); }
+};
+
 struct exception_variant {
     std::variant<unknown_exception,
             no_exception,
-            rate_limit_exception
+            rate_limit_exception,
+            stale_topology_exception
     > reason;
 
     exception_variant()

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -17,6 +17,7 @@ namespace service {
 class raft_group0_client;
 class migration_manager;
 class storage_proxy;
+class storage_service;
 
 struct schema_change {
     // Mutations of schema tables (such as `system_schema.keyspaces`, `system_schema.tables` etc.)
@@ -71,8 +72,9 @@ class group0_state_machine : public raft_state_machine {
     raft_group0_client& _client;
     migration_manager& _mm;
     storage_proxy& _sp;
+    storage_service& _ss;
 public:
-    group0_state_machine(raft_group0_client& client, migration_manager& mm, storage_proxy& sp) : _client(client), _mm(mm), _sp(sp) {}
+    group0_state_machine(raft_group0_client& client, migration_manager& mm, storage_proxy& sp, storage_service& ss) : _client(client), _mm(mm), _sp(sp), _ss(ss) {}
     future<> apply(std::vector<raft::command_cref> command) override;
     future<raft::snapshot_id> take_snapshot() override;
     void drop_snapshot(raft::snapshot_id id) override;

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -28,8 +28,12 @@ struct broadcast_table_query {
     service::broadcast_tables::query query;
 };
 
+struct topology_change {
+    std::vector<canonical_mutation> mutations;
+};
+
 struct group0_command {
-    std::variant<schema_change, broadcast_table_query> change;
+    std::variant<schema_change, broadcast_table_query, topology_change> change;
 
     // Mutation of group0 history table, appending a new state ID and optionally a description.
     canonical_mutation history_append;

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -129,8 +129,9 @@ raft_group0::raft_group0(seastar::abort_source& abort_source,
         service::migration_manager& mm,
         gms::feature_service& feat,
         db::system_keyspace& sys_ks,
-        raft_group0_client& client)
-    : _abort_source(abort_source), _raft_gr(raft_gr), _ms(ms), _gossiper(gs), _qp(qp), _mm(mm), _feat(feat), _sys_ks(sys_ks), _client(client)
+        raft_group0_client& client,
+        storage_service& ss)
+    : _abort_source(abort_source), _raft_gr(raft_gr), _ms(ms), _gossiper(gs), _qp(qp), _mm(mm), _feat(feat), _sys_ks(sys_ks), _client(client), _ss(ss)
     , _status_for_monitoring(_raft_gr.is_enabled() ? status_for_monitoring::normal : status_for_monitoring::disabled)
 {
     init_rpc_verbs();
@@ -177,7 +178,7 @@ const raft::server_id& raft_group0::load_my_id() {
 }
 
 raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, raft::server_id my_id) {
-    auto state_machine = std::make_unique<group0_state_machine>(_client, _mm, _qp.proxy());
+    auto state_machine = std::make_unique<group0_state_machine>(_client, _mm, _qp.proxy(), _ss);
     auto rpc = std::make_unique<group0_rpc>(_raft_gr.direct_fd(), *state_machine, _ms, _raft_gr.address_map(), gid, my_id);
     // Keep a reference to a specific RPC class.
     auto& rpc_ref = *rpc;

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -1535,6 +1535,10 @@ void raft_group0::register_metrics() {
     });
 }
 
+const raft_address_map& raft_group0::address_map() const {
+    return _raft_gr.address_map();
+}
+
 std::ostream& operator<<(std::ostream& os, group0_upgrade_state state) {
     switch (state) {
         case group0_upgrade_state::recovery:

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -175,6 +175,9 @@ public:
     // The returned ID is not empty.
     const raft::server_id& load_my_id();
 
+    // Remove the node from raft config, retries raft::commit_status_unknown.
+    future<> remove_from_raft_config(raft::server_id id);
+
 private:
     void init_rpc_verbs();
     future<> uninit_rpc_verbs();
@@ -246,9 +249,6 @@ private:
     // if we want to handle crashes of the group 0 server without crashing the entire Scylla process
     // (we could then try restarting the server internally).
     future<> start_server_for_group0(raft::group_id group0_id);
-
-    // Remove the node from raft config, retries raft::commit_status_unknown.
-    future<> remove_from_raft_config(raft::server_id id);
 
     // Load the initial Raft <-> IP address map as seen by
     // the gossiper.

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 #pragma once
+#include "service/raft/raft_address_map.hh"
 #include "service/raft/raft_group_registry.hh"
 #include "service/raft/discovery.hh"
 #include "service/raft/group0_fwd.hh"
@@ -178,6 +179,24 @@ public:
     // Remove the node from raft config, retries raft::commit_status_unknown.
     future<> remove_from_raft_config(raft::server_id id);
 
+    // Loads server id for group 0 from disk if present,
+    // otherwise randomly generates a new one and persists it.
+    // Execute on shard 0 only.
+    future<raft::server_id> load_or_create_my_id();
+
+    cql3::query_processor& get_qp() {
+        return _qp;
+    }
+
+    raft_group0_client& client() {
+        return _client;
+    }
+
+    raft::server& group0_server() {
+        return _raft_gr.group0();
+    }
+
+    const raft_address_map& address_map() const;
 private:
     void init_rpc_verbs();
     future<> uninit_rpc_verbs();

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -21,6 +21,7 @@ namespace service {
 
 class migration_manager;
 class raft_group0_client;
+class storage_service;
 
 // Wrapper for `discovery` which persists the learned peers on disk.
 class persistent_discovery {
@@ -73,6 +74,7 @@ class raft_group0 {
     gms::feature_service& _feat;
     db::system_keyspace& _sys_ks;
     raft_group0_client& _client;
+    service::storage_service& _ss;
 
     // Status of leader discovery. Initially there is no group 0,
     // and the variant contains no state. During initial cluster
@@ -110,7 +112,8 @@ public:
         migration_manager& mm,
         gms::feature_service& feat,
         db::system_keyspace& sys_ks,
-        raft_group0_client& client);
+        raft_group0_client& client,
+        storage_service& ss);
 
     // Return true if Raft is enabled (but not necessarily having
     // an active group 0 - e.g. in case we haven't completed an

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -283,7 +283,8 @@ future<group0_guard> raft_group0_client::start_operation(seastar::abort_source* 
     }
 }
 
-group0_command raft_group0_client::prepare_command(schema_change change, group0_guard& guard, std::string_view description) {
+template<typename Command>
+group0_command raft_group0_client::prepare_command(Command change, group0_guard& guard, std::string_view description) {
     group0_command group0_cmd {
         .change{std::move(change)},
         .history_append{db::system_keyspace::make_group0_history_state_id_mutation(
@@ -410,5 +411,8 @@ void raft_group0_client::set_query_result(utils::UUID query_id, service::broadca
         it->second = std::move(qr);
     }
 }
+
+template group0_command raft_group0_client::prepare_command(schema_change change, group0_guard& guard, std::string_view description);
+template group0_command raft_group0_client::prepare_command(topology_change change, group0_guard& guard, std::string_view description);
 
 }

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -127,8 +127,9 @@ public:
     // and add_entry would again forward to shard 0.
     future<group0_guard> start_operation(seastar::abort_source* as = nullptr);
 
-    group0_command prepare_command(schema_change change, group0_guard& guard, std::string_view description);
     group0_command prepare_command(broadcast_table_query query);
+    template<typename Command>
+    group0_command prepare_command(Command change, group0_guard& guard, std::string_view description);
 
     // Returns the current group 0 upgrade state.
     //

--- a/service/raft_bootstrap.hh
+++ b/service/raft_bootstrap.hh
@@ -1,0 +1,52 @@
+/*
+ *
+ * Modified by ScyllaDB
+ * Copyright (C) 2015-present ScyllaDB
+ *
+ */
+
+/*
+ * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <iostream>
+
+namespace service {
+// Raft leader uses this command to drive bootstrap process on other nodes
+struct raft_bootstrap_cmd {
+      enum class command: uint8_t {
+          barrier,
+          stream_ranges,
+          fence_old_reads
+      };
+      command cmd;
+};
+
+// returned as a result of raft_bootstrap_cmd
+struct raft_bootstrap_cmd_result {
+    enum class command_status: uint8_t {
+        fail,
+        success
+    };
+    command_status status = command_status::fail;
+};
+
+inline std::ostream& operator<<(std::ostream& os, const raft_bootstrap_cmd::command& cmd) {
+    switch (cmd) {
+        case raft_bootstrap_cmd::command::barrier:
+            os << "barrier";
+            break;
+        case raft_bootstrap_cmd::command::stream_ranges:
+            os << "stream_ranges";
+            break;
+        case raft_bootstrap_cmd::command::fence_old_reads:
+            os << "fence_old_reads";
+            break;
+    }
+    return os;
+}
+
+}

--- a/service/raft_bootstrap.hh
+++ b/service/raft_bootstrap.hh
@@ -49,4 +49,14 @@ inline std::ostream& operator<<(std::ostream& os, const raft_bootstrap_cmd::comm
     return os;
 }
 
+struct fencing_token {
+    int64_t topology_version;
+};
+
+inline std::ostream& operator<<(std::ostream& os, const fencing_token& fencing_token) {
+    return os << "fencing_token(" << fencing_token.topology_version << ")";
+}
+
+// todo rename to raft_topology.hh?
+
 }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -143,6 +143,12 @@ static future<rpc::tuple<Elements..., replica::exception_variant>> encode_replic
     return make_exception_future<final_tuple_type>(std::move(eptr));
 }
 
+static inline
+const dht::token& end_token(const dht::partition_range& r) {
+    static const dht::token max_token = dht::maximum_token();
+    return r.end() ? r.end()->value().token() : max_token;
+}
+
 // This class handles all communication with other nodes in `storage_proxy`:
 // sending and receiving RPCs, checking the state of other nodes (e.g. by accessing gossiper state), fetching schema.
 //
@@ -171,7 +177,16 @@ public:
 
         ser::storage_proxy_rpc_verbs::register_counter_mutation(&_ms, std::bind_front(&remote::handle_counter_mutation, this));
         ser::storage_proxy_rpc_verbs::register_mutation(&_ms, std::bind_front(&remote::receive_mutation_handler, this, sp->_write_smp_service_group));
-        ser::storage_proxy_rpc_verbs::register_hint_mutation(&_ms, [this, sp] <typename... Args>(Args&&... args) { return receive_mutation_handler(sp->_hints_write_smp_service_group, std::forward<Args>(args)..., std::monostate()); });
+        ser::storage_proxy_rpc_verbs::register_hint_mutation(&_ms, [this, sp] (const rpc::client_info& cinfo,
+            rpc::opt_time_point t, frozen_mutation in,
+            inet_address_vector_replica_set forward, gms::inet_address reply_to,
+            unsigned shard, storage_proxy::response_id_type response_id,
+            rpc::optional<std::optional<tracing::trace_info>> trace_info,
+            rpc::optional<fencing_token> fence) {
+            return receive_mutation_handler(sp->_hints_write_smp_service_group, cinfo, t, std::move(in),
+                std::move(forward), std::move(reply_to), shard, response_id, std::move(trace_info),
+                std::monostate(), std::move(fence));
+        });
         ser::storage_proxy_rpc_verbs::register_paxos_learn(&_ms, std::bind_front(&remote::handle_paxos_learn, this));
         ser::storage_proxy_rpc_verbs::register_mutation_done(&_ms, std::bind_front(&remote::handle_mutation_done, this));
         ser::storage_proxy_rpc_verbs::register_mutation_failed(&_ms, std::bind_front(&remote::handle_mutation_failed, this));
@@ -201,31 +216,34 @@ public:
     future<> send_mutation(
             netw::msg_addr addr, storage_proxy::clock_type::time_point timeout, std::optional<tracing::trace_info> trace_info,
             frozen_mutation m, inet_address_vector_replica_set&& forward, gms::inet_address reply_to, unsigned shard,
-            storage_proxy::response_id_type response_id, db::per_partition_rate_limit::info rate_limit_info) {
+            storage_proxy::response_id_type response_id, db::per_partition_rate_limit::info rate_limit_info,
+            fencing_token fencing_token) {
         return ser::storage_proxy_rpc_verbs::send_mutation(
                 &_ms, std::move(addr), timeout,
                 std::move(m), std::move(forward), std::move(reply_to), shard,
-                response_id, std::move(trace_info), rate_limit_info);
+                response_id, std::move(trace_info), rate_limit_info,
+                fencing_token);
     }
 
     future<> send_hint_mutation(
             netw::msg_addr addr, storage_proxy::clock_type::time_point timeout, tracing::trace_state_ptr tr_state,
             frozen_mutation m, inet_address_vector_replica_set&& forward, gms::inet_address reply_to, unsigned shard,
-            storage_proxy::response_id_type response_id, db::per_partition_rate_limit::info rate_limit_info) {
+            storage_proxy::response_id_type response_id, db::per_partition_rate_limit::info rate_limit_info,
+            fencing_token fence) {
         tracing::trace(tr_state, "Sending a hint to /{}", addr.addr);
         return ser::storage_proxy_rpc_verbs::send_hint_mutation(
                 &_ms, std::move(addr), timeout,
                 std::move(m), std::move(forward), std::move(reply_to), shard,
-                response_id, tracing::make_trace_info(tr_state));
+                response_id, tracing::make_trace_info(tr_state), fence);
     }
 
     future<> send_counter_mutation(
             netw::msg_addr addr, storage_proxy::clock_type::time_point timeout, tracing::trace_state_ptr tr_state,
-            std::vector<frozen_mutation> fms, db::consistency_level cl) {
+            std::vector<frozen_mutation> fms, db::consistency_level cl, fencing_token fence) {
         tracing::trace(tr_state, "Enqueuing counter update to {}", addr);
         return ser::storage_proxy_rpc_verbs::send_counter_mutation(
                 &_ms, std::move(addr), timeout,
-                std::move(fms), cl, tracing::make_trace_info(tr_state));
+                std::move(fms), cl, tracing::make_trace_info(tr_state), fence);
     }
 
     future<> send_mutation_done(
@@ -249,9 +267,9 @@ public:
     future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>
     send_read_mutation_data(
             netw::msg_addr addr, storage_proxy::clock_type::time_point timeout, tracing::trace_state_ptr tr_state,
-            const query::read_command& cmd, const dht::partition_range& pr) {
+            const query::read_command& cmd, const dht::partition_range& pr, fencing_token fence) {
         tracing::trace(tr_state, "read_mutation_data: sending a message to /{}", addr.addr);
-        auto&& [result, hit_rate, opt_exception] = co_await ser::storage_proxy_rpc_verbs::send_read_mutation_data(&_ms, addr, timeout, cmd, pr);
+        auto&& [result, hit_rate, opt_exception] = co_await ser::storage_proxy_rpc_verbs::send_read_mutation_data(&_ms, addr, timeout, cmd, pr, fence);
         if (opt_exception.has_value() && *opt_exception) {
             co_await coroutine::return_exception_ptr((*opt_exception).into_exception_ptr());
         }
@@ -264,10 +282,10 @@ public:
     send_read_data(
             netw::msg_addr addr, storage_proxy::clock_type::time_point timeout, tracing::trace_state_ptr tr_state,
             const query::read_command& cmd, const dht::partition_range& pr,
-            query::digest_algorithm digest_algo, db::per_partition_rate_limit::info rate_limit_info) {
+            query::digest_algorithm digest_algo, db::per_partition_rate_limit::info rate_limit_info, fencing_token fence) {
         tracing::trace(tr_state, "read_data: sending a message to /{}", addr.addr);
         auto&& [result, hit_rate, opt_exception] =
-            co_await ser::storage_proxy_rpc_verbs::send_read_data(&_ms, addr, timeout, cmd, pr, digest_algo, rate_limit_info);
+            co_await ser::storage_proxy_rpc_verbs::send_read_data(&_ms, addr, timeout, cmd, pr, digest_algo, rate_limit_info, fence);
         if (opt_exception.has_value() && *opt_exception) {
             co_await coroutine::return_exception_ptr((*opt_exception).into_exception_ptr());
         }
@@ -280,10 +298,10 @@ public:
     send_read_digest(
             netw::msg_addr addr, storage_proxy::clock_type::time_point timeout, tracing::trace_state_ptr tr_state,
             const query::read_command& cmd, const dht::partition_range& pr,
-            query::digest_algorithm digest_algo, db::per_partition_rate_limit::info rate_limit_info) {
+            query::digest_algorithm digest_algo, db::per_partition_rate_limit::info rate_limit_info, fencing_token fence) {
         tracing::trace(tr_state, "read_digest: sending a message to /{}", addr.addr);
         auto&& [d, t, hit_rate, opt_exception, opt_last_pos] =
-            co_await ser::storage_proxy_rpc_verbs::send_read_digest(&_ms, addr, timeout, cmd, pr, digest_algo, rate_limit_info);
+            co_await ser::storage_proxy_rpc_verbs::send_read_digest(&_ms, addr, timeout, cmd, pr, digest_algo, rate_limit_info, fence);
         if (opt_exception.has_value() && *opt_exception) {
             co_await coroutine::return_exception_ptr((*opt_exception).into_exception_ptr());
         }
@@ -316,9 +334,9 @@ public:
     future<> send_paxos_learn(
             netw::msg_addr addr, storage_proxy::clock_type::time_point timeout, std::optional<tracing::trace_info> trace_info,
             const service::paxos::proposal& decision, inet_address_vector_replica_set&& forward,
-            gms::inet_address reply_to, unsigned shard, uint64_t response_id) {
+            gms::inet_address reply_to, unsigned shard, uint64_t response_id, fencing_token fencing_token) {
         return ser::storage_proxy_rpc_verbs::send_paxos_learn(
-                &_ms, addr, timeout, decision, std::move(forward), reply_to, shard, response_id, std::move(trace_info));
+                &_ms, addr, timeout, decision, std::move(forward), reply_to, shard, response_id, std::move(trace_info), fencing_token);
     }
 
     future<> send_paxos_prune(
@@ -370,7 +388,8 @@ private:
 
     future<> handle_counter_mutation(
             const rpc::client_info& cinfo, rpc::opt_time_point t,
-            std::vector<frozen_mutation> fms, db::consistency_level cl, std::optional<tracing::trace_info> trace_info) {
+            std::vector<frozen_mutation> fms, db::consistency_level cl, std::optional<tracing::trace_info> trace_info,
+            rpc::optional<fencing_token> fencing_token) {
         auto src_addr = netw::messaging_service::get_source(cinfo);
 
         tracing::trace_state_ptr trace_state_ptr;
@@ -380,8 +399,20 @@ private:
             tracing::trace(trace_state_ptr, "Message received from /{}", src_addr.addr);
         }
 
-        std::vector<frozen_mutation_and_schema> mutations;
         auto timeout = *t;
+        if (fencing_token && !fms.empty()) {
+            const auto& fm = fms[0];
+            auto stale_topology = co_await _sp.try_apply_fence(*fencing_token, timeout, [&]() -> future<request_info> {
+                auto schema = co_await get_schema_for_write(fm.schema_version(), src_addr);
+                co_return request_info{schema, schema->get_partitioner().get_token(*schema, fm.key())};
+            });
+            if (stale_topology) {
+                // todo: do it right
+                throw *stale_topology;
+            }
+        }
+
+        std::vector<frozen_mutation_and_schema> mutations;
         co_await coroutine::parallel_for_each(std::move(fms), [&] (frozen_mutation& fm) {
             // Note: not a coroutine, since get_schema_for_write() rarely blocks.
             // FIXME: optimise for cases when all fms are in the same schema
@@ -398,6 +429,7 @@ private:
             netw::messaging_service::msg_addr src_addr, rpc::opt_time_point t,
             auto schema_version, auto in, inet_address_vector_replica_set forward, gms::inet_address reply_to,
             unsigned shard, storage_proxy::response_id_type response_id, std::optional<tracing::trace_info> trace_info,
+            rpc::optional<fencing_token> fencing_token, std::optional<partition_key_view> partition_key,
             auto&& apply_fn1, auto&& forward_fn1) {
         auto apply_fn = std::move(apply_fn1);
         auto forward_fn = std::move(forward_fn1);
@@ -433,51 +465,73 @@ private:
         errors_info errors;
         ++p->get_stats().received_mutations;
         p->get_stats().forwarded_mutations += forward.size();
-        co_await coroutine::all(
-            [&] () -> future<> {
-                try {
-                    // FIXME: get_schema_for_write() doesn't timeout
-                    schema_ptr s = co_await get_schema_for_write(schema_version, netw::messaging_service::msg_addr{reply_to, shard});
-                    // Note: blocks due to execution_stage in replica::database::apply()
-                    co_await apply_fn(p, trace_state_ptr, std::move(s), m, timeout);
-                    // We wait for send_mutation_done to complete, otherwise, if reply_to is busy, we will accumulate
-                    // lots of unsent responses, which can OOM our shard.
-                    //
-                    // Usually we will return immediately, since this work only involves appending data to the connection
-                    // send buffer.
-                    auto f = co_await coroutine::as_future(send_mutation_done(netw::messaging_service::msg_addr{reply_to, shard}, trace_state_ptr,
-                            shard, response_id, p->get_view_update_backlog()));
-                    f.ignore_ready_future();
-                } catch (...) {
-                    std::exception_ptr eptr = std::current_exception();
-                    errors.count++;
-                    errors.local = replica::try_encode_replica_exception(eptr);
-                    seastar::log_level l = seastar::log_level::warn;
-                    if (is_timeout_exception(eptr) || std::holds_alternative<replica::rate_limit_exception>(errors.local.reason)) {
-                        // ignore timeouts and rate limit exceptions so that logs are not flooded.
-                        // database's total_writes_timedout or total_writes_rate_limited counter was incremented.
-                        l = seastar::log_level::debug;
-                    }
-                    slogger.log(l, "Failed to apply mutation from {}#{}: {}", reply_to, shard, eptr);
-                }
-            },
-            [&] {
-                // Note: not a coroutine, since often nothing needs to be forwarded and this returns a ready future
-                return parallel_for_each(forward.begin(), forward.end(), [&] (gms::inet_address forward) {
-                    // Note: not a coroutine, since forward_fn() typically returns a ready future
-                    tracing::trace(trace_state_ptr, "Forwarding a mutation to /{}", forward);
-                    return forward_fn(p, netw::messaging_service::msg_addr{forward, 0}, timeout, m, reply_to, shard, response_id,
-                                        tracing::make_trace_info(trace_state_ptr))
-                            .then_wrapped([&] (future<> f) {
-                        if (f.failed()) {
-                            ++p->get_stats().forwarding_errors;
-                            errors.count++;
-                        };
-                        f.ignore_ready_future();
-                    });
-                });
+
+        auto get_schema = [&, s = schema_ptr()]() mutable -> future<schema_ptr> {
+            // FIXME: get_schema_for_write() doesn't timeout
+            if (!s) {
+                s = co_await get_schema_for_write(schema_version, netw::messaging_service::msg_addr{reply_to, shard});
             }
-        );
+            co_return s;
+        };
+
+        if (fencing_token) {
+            assert(partition_key.has_value());
+            auto stale_topology = co_await _sp.try_apply_fence(*fencing_token, timeout, [&]() -> future<request_info> {
+                const auto schema = co_await get_schema();
+                co_return request_info{schema, schema->get_partitioner().get_token(*schema, *partition_key)};
+            });
+            if (stale_topology) {
+                errors.count += (forward.size() + 1);
+                errors.local = std::move(*stale_topology);
+            }
+        }
+
+        if (errors.count == 0) {
+            co_await coroutine::all(
+                [&] () -> future<> {
+                    try {
+                        // Note: blocks due to execution_stage in replica::database::apply()
+                        co_await apply_fn(p, trace_state_ptr, co_await get_schema(), m, timeout);
+                        // We wait for send_mutation_done to complete, otherwise, if reply_to is busy, we will accumulate
+                        // lots of unsent responses, which can OOM our shard.
+                        //
+                        // Usually we will return immediately, since this work only involves appending data to the connection
+                        // send buffer.
+                        auto f = co_await coroutine::as_future(send_mutation_done(netw::messaging_service::msg_addr{reply_to, shard}, trace_state_ptr,
+                            shard, response_id, p->get_view_update_backlog()));
+                        f.ignore_ready_future();
+                    } catch (...) {
+                        std::exception_ptr eptr = std::current_exception();
+                        errors.count++;
+                        errors.local = replica::try_encode_replica_exception(eptr);
+                        seastar::log_level l = seastar::log_level::warn;
+                        if (is_timeout_exception(eptr) || std::holds_alternative<replica::rate_limit_exception>(errors.local.reason)) {
+                            // ignore timeouts and rate limit exceptions so that logs are not flooded.
+                            // database's total_writes_timedout or total_writes_rate_limited counter was incremented.
+                            l = seastar::log_level::debug;
+                        }
+                        slogger.log(l, "Failed to apply mutation from {}#{}: {}", reply_to, shard, eptr);
+                    }
+                },
+                [&] {
+                    // Note: not a coroutine, since often nothing needs to be forwarded and this returns a ready future
+                    return parallel_for_each(forward.begin(), forward.end(), [&] (gms::inet_address forward) {
+                        // Note: not a coroutine, since forward_fn() typically returns a ready future
+                        tracing::trace(trace_state_ptr, "Forwarding a mutation to /{}", forward);
+                        return forward_fn(p, netw::messaging_service::msg_addr{forward, 0}, timeout, m, reply_to, shard, response_id,
+                            tracing::make_trace_info(trace_state_ptr))
+                            .then_wrapped([&] (future<> f) {
+                                if (f.failed()) {
+                                    ++p->get_stats().forwarding_errors;
+                                    errors.count++;
+                                };
+                                f.ignore_ready_future();
+                            });
+                    });
+                }
+            );
+        }
+
         // ignore results, since we'll be returning them via MUTATION_DONE/MUTATION_FAILURE verbs
         if (errors.count) {
             auto f = co_await coroutine::as_future(send_mutation_failed(
@@ -497,7 +551,9 @@ private:
             smp_service_group smp_grp, const rpc::client_info& cinfo, rpc::opt_time_point t,
             frozen_mutation in, inet_address_vector_replica_set forward, gms::inet_address reply_to,
             unsigned shard, storage_proxy::response_id_type response_id,
-            rpc::optional<std::optional<tracing::trace_info>> trace_info, rpc::optional<db::per_partition_rate_limit::info> rate_limit_info_opt) {
+            rpc::optional<std::optional<tracing::trace_info>> trace_info,
+            rpc::optional<db::per_partition_rate_limit::info> rate_limit_info_opt,
+            rpc::optional<fencing_token> fence) {
         tracing::trace_state_ptr trace_state_ptr;
         auto src_addr = netw::messaging_service::get_source(cinfo);
         auto rate_limit_info = rate_limit_info_opt.value_or(std::monostate());
@@ -505,35 +561,38 @@ private:
         auto schema_version = in.schema_version();
         return handle_write(src_addr, t, schema_version, std::move(in), std::move(forward), reply_to, shard, response_id,
                 trace_info ? *trace_info : std::nullopt,
+                fence, in.key(),
                 /* apply_fn */ [smp_grp, rate_limit_info] (shared_ptr<storage_proxy>& p, tracing::trace_state_ptr tr_state, schema_ptr s, const frozen_mutation& m,
                         clock_type::time_point timeout) {
                     return p->mutate_locally(std::move(s), m, std::move(tr_state), db::commitlog::force_sync::no, timeout, smp_grp, rate_limit_info);
                 },
-                /* forward_fn */ [this, rate_limit_info] (shared_ptr<storage_proxy>& p, netw::messaging_service::msg_addr addr, clock_type::time_point timeout, const frozen_mutation& m,
+                /* forward_fn */ [this, rate_limit_info, fence] (shared_ptr<storage_proxy>& p, netw::messaging_service::msg_addr addr, clock_type::time_point timeout, const frozen_mutation& m,
                         gms::inet_address reply_to, unsigned shard, response_id_type response_id,
                         std::optional<tracing::trace_info> trace_info) {
-                    return send_mutation(addr, timeout, std::move(trace_info), m, {}, reply_to, shard, response_id, rate_limit_info);
+                    return send_mutation(addr, timeout, std::move(trace_info), m, {}, reply_to, shard, response_id, rate_limit_info, fence ? *fence: fencing_token{0});
                 });
     }
 
     future<rpc::no_wait_type> handle_paxos_learn(
             const rpc::client_info& cinfo, rpc::opt_time_point t,
             paxos::proposal decision, inet_address_vector_replica_set forward, gms::inet_address reply_to, unsigned shard,
-            storage_proxy::response_id_type response_id, std::optional<tracing::trace_info> trace_info) {
+            storage_proxy::response_id_type response_id, std::optional<tracing::trace_info> trace_info,
+            rpc::optional<fencing_token> fence) {
         tracing::trace_state_ptr trace_state_ptr;
         auto src_addr = netw::messaging_service::get_source(cinfo);
 
         auto schema_version = decision.update.schema_version();
         return handle_write(src_addr, t, schema_version, std::move(decision), std::move(forward), reply_to, shard,
                 response_id, trace_info,
+                fence, decision.update.key(),
                /* apply_fn */ [] (shared_ptr<storage_proxy>& p, tracing::trace_state_ptr tr_state, schema_ptr s,
                        const paxos::proposal& decision, clock_type::time_point timeout) {
                      return paxos::paxos_state::learn(*p, std::move(s), decision, timeout, tr_state);
               },
-              /* forward_fn */ [this] (shared_ptr<storage_proxy>&, netw::messaging_service::msg_addr addr, clock_type::time_point timeout, const paxos::proposal& m,
+              /* forward_fn */ [this, fence] (shared_ptr<storage_proxy>&, netw::messaging_service::msg_addr addr, clock_type::time_point timeout, const paxos::proposal& m,
                       gms::inet_address reply_to, unsigned shard, response_id_type response_id,
                       std::optional<tracing::trace_info> trace_info) {
-                    return send_paxos_learn(addr, timeout, std::move(trace_info), m, {}, reply_to, shard, response_id);
+                    return send_paxos_learn(addr, timeout, std::move(trace_info), m, {}, reply_to, shard, response_id, fence ? *fence: fencing_token{0});
               });
     }
 
@@ -558,16 +617,21 @@ private:
         return _sp.container().invoke_on(shard, _sp._write_ack_smp_service_group,
                 [from, response_id, num_failed, backlog = std::move(backlog), exception = std::move(exception)] (storage_proxy& sp) mutable {
             error err = error::FAILURE;
+            std::optional<sstring> msg;
             if (exception) {
-                err = std::visit([] <typename Ex> (Ex&) {
+                err = std::visit([&] <typename Ex> (Ex& e) {
                     if constexpr (std::is_same_v<Ex, replica::rate_limit_exception>) {
+                        msg = e.what();
                         return error::RATE_LIMIT;
                     } else if constexpr (std::is_same_v<Ex, replica::unknown_exception> || std::is_same_v<Ex, replica::no_exception>) {
+                        return error::FAILURE;
+                    } else if constexpr(std::is_same_v<Ex, replica::stale_topology_exception>) {
+                        msg = e.what();
                         return error::FAILURE;
                     }
                 }, exception->reason);
             }
-            sp.got_failure_response(response_id, from, num_failed, std::move(backlog), err, std::nullopt);
+            sp.got_failure_response(response_id, from, num_failed, std::move(backlog), err, std::move(msg));
             return netw::messaging_service::no_wait();
         });
     }
@@ -576,7 +640,8 @@ private:
     handle_read_data(
             const rpc::client_info& cinfo, rpc::opt_time_point t,
             query::read_command cmd1, ::compat::wrapping_partition_range pr,
-            rpc::optional<query::digest_algorithm> oda, rpc::optional<db::per_partition_rate_limit::info> rate_limit_info_opt) {
+            rpc::optional<query::digest_algorithm> oda, rpc::optional<db::per_partition_rate_limit::info> rate_limit_info_opt,
+            rpc::optional<fencing_token> fencing_token) {
         tracing::trace_state_ptr trace_state_ptr;
         auto src_addr = netw::messaging_service::get_source(cinfo);
         if (cmd1.trace_info) {
@@ -605,7 +670,11 @@ private:
         opts.digest_algo = da;
         opts.request = da == query::digest_algorithm::none ? query::result_request::only_result : query::result_request::result_and_digest;
         auto timeout = t ? *t : db::no_timeout;
-        future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> f = co_await coroutine::as_future(p->query_result_local(std::move(s), cmd, std::move(pr2.first), opts, trace_state_ptr, timeout, rate_limit_info));
+
+        auto stale_topology = fencing_token ? co_await _sp.try_apply_fence(*fencing_token, timeout, pr2.first, s) : std::nullopt;
+        auto f = stale_topology
+            ? make_exception_future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>>(std::move(*stale_topology))
+            : co_await coroutine::as_future(p->query_result_local(std::move(s), cmd, std::move(pr2.first), opts, trace_state_ptr, timeout, rate_limit_info));
         tracing::trace(trace_state_ptr, "read_data handling is done, sending a response to /{}", src_ip);
         co_return co_await encode_replica_exception_for_rpc(p->features(), std::move(f), [] { return std::make_tuple(foreign_ptr(make_lw_shared<query::result>()), cache_temperature::invalid()); });
     }
@@ -613,7 +682,8 @@ private:
     future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature, replica::exception_variant>>
     handle_read_mutation_data(
             const rpc::client_info& cinfo, rpc::opt_time_point t,
-            query::read_command cmd1, ::compat::wrapping_partition_range pr) {
+            query::read_command cmd1, ::compat::wrapping_partition_range pr,
+            rpc::optional<fencing_token> fencing_token) {
         tracing::trace_state_ptr trace_state_ptr;
         auto src_addr = netw::messaging_service::get_source(cinfo);
         if (cmd1.trace_info) {
@@ -632,7 +702,11 @@ private:
         auto s = co_await get_schema_for_read(cmd->schema_version, std::move(src_addr));
         unwrapped = ::compat::unwrap(std::move(pr), *s);
         auto timeout = t ? *t : db::no_timeout;
-        future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>> f = co_await coroutine::as_future(p->query_mutations_locally(std::move(s), std::move(cmd), unwrapped, timeout, trace_state_ptr));
+
+        auto stale_topology = fencing_token ? co_await _sp.try_apply_fence(*fencing_token, timeout, unwrapped.first, s) : std::nullopt;
+        auto f = stale_topology
+            ? make_exception_future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>(std::move(*stale_topology))
+            : co_await coroutine::as_future(p->query_mutations_locally(std::move(s), std::move(cmd), unwrapped, timeout, trace_state_ptr));
         tracing::trace(trace_state_ptr, "read_mutation_data handling is done, sending a response to /{}", src_ip);
         co_return co_await encode_replica_exception_for_rpc(p->features(), std::move(f), [] { return std::make_tuple(foreign_ptr(make_lw_shared<reconcilable_result>()), cache_temperature::invalid()); });
     }
@@ -641,7 +715,8 @@ private:
     handle_read_digest(
             const rpc::client_info& cinfo, rpc::opt_time_point t,
             query::read_command cmd1, ::compat::wrapping_partition_range pr,
-            rpc::optional<query::digest_algorithm> oda, rpc::optional<db::per_partition_rate_limit::info> rate_limit_info_opt) {
+            rpc::optional<query::digest_algorithm> oda, rpc::optional<db::per_partition_rate_limit::info> rate_limit_info_opt,
+            rpc::optional<fencing_token> fencing_token) {
         tracing::trace_state_ptr trace_state_ptr;
         auto src_addr = netw::messaging_service::get_source(cinfo);
         if (cmd1.trace_info) {
@@ -665,7 +740,11 @@ private:
             throw std::runtime_error("READ_DIGEST called with wrapping range");
         }
         auto timeout = t ? *t : db::no_timeout;
-        future<rpc::tuple<query::result_digest, api::timestamp_type, cache_temperature, std::optional<full_position>>> f = co_await coroutine::as_future(p->query_result_local_digest(std::move(s), cmd, std::move(pr2.first), trace_state_ptr, timeout, da, rate_limit_info));
+
+        auto stale_topology = co_await _sp.try_apply_fence(*fencing_token, timeout, pr2.first, s);
+        auto f = stale_topology
+            ? make_exception_future<rpc::tuple<query::result_digest, api::timestamp_type, cache_temperature, std::optional<full_position>>>(std::move(*stale_topology))
+            : co_await coroutine::as_future(p->query_result_local_digest(std::move(s), cmd, std::move(pr2.first), trace_state_ptr, timeout, da, rate_limit_info));
         tracing::trace(trace_state_ptr, "read_digest handling is done, sending a response to /{}", src_ip);
 
         using final_tuple_type = rpc::tuple<query::result_digest, long, cache_temperature, replica::exception_variant, std::optional<full_position>>;
@@ -817,12 +896,6 @@ query::digest_algorithm digest_algorithm(service::storage_proxy& proxy) {
             : query::digest_algorithm::legacy_xxHash_without_null_digest;
 }
 
-static inline
-const dht::token& end_token(const dht::partition_range& r) {
-    static const dht::token max_token = dht::maximum_token();
-    return r.end() ? r.end()->value().token() : max_token;
-}
-
 unsigned storage_proxy::cas_shard(const schema& s, dht::token token) {
     return dht::shard_of(s, token);
 }
@@ -891,7 +964,8 @@ public:
             tracing::trace_state_ptr tr_state, db::per_partition_rate_limit::info rate_limit_info) = 0;
     virtual future<> apply_remotely(storage_proxy& sp, gms::inet_address ep, inet_address_vector_replica_set&& forward,
             storage_proxy::response_id_type response_id, storage_proxy::clock_type::time_point timeout,
-            tracing::trace_state_ptr tr_state, db::per_partition_rate_limit::info rate_limit_info) = 0;
+            tracing::trace_state_ptr tr_state, db::per_partition_rate_limit::info rate_limit_info,
+            fencing_token fence) = 0;
     virtual bool is_shared() = 0;
     size_t size() const {
         return _size;
@@ -942,13 +1016,14 @@ public:
     }
     virtual future<> apply_remotely(storage_proxy& sp, gms::inet_address ep, inet_address_vector_replica_set&& forward,
             storage_proxy::response_id_type response_id, storage_proxy::clock_type::time_point timeout,
-            tracing::trace_state_ptr tr_state, db::per_partition_rate_limit::info rate_limit_info) override {
+            tracing::trace_state_ptr tr_state, db::per_partition_rate_limit::info rate_limit_info,
+            fencing_token fence) override {
         auto m = _mutations[ep];
         if (m) {
             tracing::trace(tr_state, "Sending a mutation to /{}", ep);
             return sp.remote().send_mutation(netw::messaging_service::msg_addr{ep, 0}, timeout, tracing::make_trace_info(tr_state),
                     *m, std::move(forward), utils::fb_utilities::get_broadcast_address(), this_shard_id(),
-                    response_id, rate_limit_info);
+                    response_id, rate_limit_info, fence);
         }
         sp.got_response(response_id, ep, std::nullopt);
         return make_ready_future<>();
@@ -990,11 +1065,12 @@ public:
     }
     virtual future<> apply_remotely(storage_proxy& sp, gms::inet_address ep, inet_address_vector_replica_set&& forward,
             storage_proxy::response_id_type response_id, storage_proxy::clock_type::time_point timeout,
-            tracing::trace_state_ptr tr_state, db::per_partition_rate_limit::info rate_limit_info) override {
+            tracing::trace_state_ptr tr_state, db::per_partition_rate_limit::info rate_limit_info,
+            fencing_token fence) override {
         tracing::trace(tr_state, "Sending a mutation to /{}", ep);
         return sp.remote().send_mutation(netw::messaging_service::msg_addr{ep, 0}, timeout, tracing::make_trace_info(tr_state),
                 *_mutation, std::move(forward), utils::fb_utilities::get_broadcast_address(), this_shard_id(),
-                response_id, rate_limit_info);
+                response_id, rate_limit_info, fence);
     }
     virtual bool is_shared() override {
         return true;
@@ -1019,10 +1095,11 @@ public:
     }
     virtual future<> apply_remotely(storage_proxy& sp, gms::inet_address ep, inet_address_vector_replica_set&& forward,
             storage_proxy::response_id_type response_id, storage_proxy::clock_type::time_point timeout,
-            tracing::trace_state_ptr tr_state, db::per_partition_rate_limit::info rate_limit_info) override {
+            tracing::trace_state_ptr tr_state, db::per_partition_rate_limit::info rate_limit_info,
+            fencing_token fence) override {
         return sp.remote().send_hint_mutation(
                 netw::messaging_service::msg_addr{ep, 0}, timeout, tr_state,
-                *_mutation, std::move(forward), utils::fb_utilities::get_broadcast_address(), this_shard_id(), response_id, rate_limit_info);
+                *_mutation, std::move(forward), utils::fb_utilities::get_broadcast_address(), this_shard_id(), response_id, rate_limit_info, fence);
     }
 };
 
@@ -1139,12 +1216,14 @@ public:
     }
     virtual future<> apply_remotely(storage_proxy& sp, gms::inet_address ep, inet_address_vector_replica_set&& forward,
             storage_proxy::response_id_type response_id, storage_proxy::clock_type::time_point timeout,
-            tracing::trace_state_ptr tr_state, db::per_partition_rate_limit::info rate_limit_info) override {
+            tracing::trace_state_ptr tr_state, db::per_partition_rate_limit::info rate_limit_info,
+            fencing_token fence) override {
         tracing::trace(tr_state, "Sending a learn to /{}", ep);
         // TODO: Enforce per partition rate limiting in paxos
         return sp.remote().send_paxos_learn(
                 netw::messaging_service::msg_addr{ep, 0}, timeout, tracing::make_trace_info(tr_state),
-                *_proposal, std::move(forward), utils::fb_utilities::get_broadcast_address(), this_shard_id(), response_id);
+                *_proposal, std::move(forward), utils::fb_utilities::get_broadcast_address(), this_shard_id(), response_id,
+                fence);
     }
     virtual bool is_shared() override {
         return true;
@@ -1436,7 +1515,7 @@ public:
     future<> apply_remotely(gms::inet_address ep, inet_address_vector_replica_set&& forward,
             storage_proxy::response_id_type response_id, storage_proxy::clock_type::time_point timeout,
             tracing::trace_state_ptr tr_state) {
-        return _mutation_holder->apply_remotely(*_proxy, ep, std::move(forward), response_id, timeout, std::move(tr_state), _rate_limit_info);
+        return _mutation_holder->apply_remotely(*_proxy, ep, std::move(forward), response_id, timeout, std::move(tr_state), _rate_limit_info, fencing_token{_effective_replication_map_ptr->get_token_metadata_ptr()->get_topology_version()});
     }
     const schema_ptr& get_schema() const {
         return _mutation_holder->schema();
@@ -3141,6 +3220,7 @@ future<> storage_proxy::mutate_counters(Range&& mutations, db::consistency_level
     // The interface doesn't preclude multiple keyspaces (and thus effective_replication_maps),
     // so we need a container for them. std::set<> will result in the fewest allocations if there is just one.
     std::set<locator::effective_replication_map_ptr> erms;
+    fencing_token fence{_shared_token_metadata.get()->get_topology_version()};
 
     for (auto& m : mutations) {
         auto& ks = _db.local().find_keyspace(m.schema()->ks_name());
@@ -3153,7 +3233,7 @@ future<> storage_proxy::mutate_counters(Range&& mutations, db::consistency_level
 
     // Forward mutations to the leaders chosen for them
     auto my_address = utils::fb_utilities::get_broadcast_address();
-    co_await coroutine::parallel_for_each(leaders, [this, cl, timeout, tr_state = std::move(tr_state), permit = std::move(permit), my_address] (auto& endpoint_and_mutations) -> future<> {
+    co_await coroutine::parallel_for_each(leaders, [this, cl, timeout, tr_state = std::move(tr_state), permit = std::move(permit), my_address, fence] (auto& endpoint_and_mutations) -> future<> {
       auto first_schema = endpoint_and_mutations.second[0].s;
 
       try {
@@ -3173,7 +3253,7 @@ future<> storage_proxy::mutate_counters(Range&& mutations, db::consistency_level
 
             co_await remote().send_counter_mutation(
                     netw::messaging_service::msg_addr{ endpoint_and_mutations.first, 0 }, timeout, tr_state,
-                    std::move(fms), cl);
+                    std::move(fms), cl, fence);
         }
       } catch (...) {
         // The leader receives a vector of mutations and processes them together,
@@ -4613,6 +4693,10 @@ private:
         return _effective_replication_map_ptr->get_topology();
     }
 
+    fencing_token get_fence() const {
+        return fencing_token{_effective_replication_map_ptr->get_token_metadata_ptr()->get_topology_version()};
+    }
+
 public:
     abstract_read_executor(schema_ptr s, lw_shared_ptr<replica::column_family> cf, shared_ptr<storage_proxy> proxy,
             locator::effective_replication_map_ptr ermp,
@@ -4645,7 +4729,7 @@ protected:
             tracing::trace(_trace_state, "read_mutation_data: querying locally");
             return _proxy->query_mutations_locally(_schema, cmd, _partition_range, timeout, _trace_state);
         } else {
-            return _proxy->remote().send_read_mutation_data(netw::messaging_service::msg_addr{ep, 0}, timeout, _trace_state, *cmd, _partition_range);
+            return _proxy->remote().send_read_mutation_data(netw::messaging_service::msg_addr{ep, 0}, timeout, _trace_state, *cmd, _partition_range, get_fence());
         }
     }
     future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> make_data_request(gms::inet_address ep, clock_type::time_point timeout, bool want_digest) {
@@ -4657,7 +4741,7 @@ protected:
             tracing::trace(_trace_state, "read_data: querying locally");
             return _proxy->query_result_local(_schema, _cmd, _partition_range, opts, _trace_state, timeout, adjust_rate_limit_for_local_operation(_rate_limit_info));
         } else {
-            return _proxy->remote().send_read_data(netw::messaging_service::msg_addr{ep, 0}, timeout, _trace_state, *_cmd, _partition_range, opts.digest_algo, _rate_limit_info);
+            return _proxy->remote().send_read_data(netw::messaging_service::msg_addr{ep, 0}, timeout, _trace_state, *_cmd, _partition_range, opts.digest_algo, _rate_limit_info, get_fence());
         }
     }
     future<rpc::tuple<query::result_digest, api::timestamp_type, cache_temperature, std::optional<full_position>>> make_digest_request(gms::inet_address ep, clock_type::time_point timeout) {
@@ -4668,7 +4752,7 @@ protected:
                         timeout, digest_algorithm(*_proxy), adjust_rate_limit_for_local_operation(_rate_limit_info));
         } else {
             tracing::trace(_trace_state, "read_digest: sending a message to /{}", ep);
-            return _proxy->remote().send_read_digest(netw::messaging_service::msg_addr{ep, 0}, timeout, _trace_state, *_cmd, _partition_range, digest_algorithm(*_proxy), _rate_limit_info);
+            return _proxy->remote().send_read_digest(netw::messaging_service::msg_addr{ep, 0}, timeout, _trace_state, *_cmd, _partition_range, digest_algorithm(*_proxy), _rate_limit_info, get_fence());
         }
     }
     void make_mutation_data_requests(lw_shared_ptr<query::read_command> cmd, data_resolver_ptr resolver, targets_iterator begin, targets_iterator end, clock_type::time_point timeout) {
@@ -6274,6 +6358,47 @@ locator::token_metadata_ptr storage_proxy::get_token_metadata_ptr() const noexce
 
 future<std::vector<dht::token_range_endpoints>> storage_proxy::describe_ring(const sstring& keyspace, bool include_only_local_dc) const {
     return locator::describe_ring(_db.local(), _remote->gossiper(), keyspace, include_only_local_dc);
+}
+
+future<std::optional<replica::stale_topology_exception>> storage_proxy::try_apply_fence(fencing_token fencing_token,
+    lowres_clock::time_point timeout,
+    const dht::partition_range& range, schema_ptr schema)
+{
+    return try_apply_fence(fencing_token, timeout, [r = request_info{std::move(schema), end_token(range)}]() mutable {
+        return make_ready_future<request_info>(std::move(r));
+    });
+}
+
+future<std::optional<replica::stale_topology_exception>> storage_proxy::try_apply_fence(fencing_token fencing_token,
+    lowres_clock::time_point timeout,
+    noncopyable_function<future<request_info>()>&& get_request_info)
+{
+    while (true) {
+        const auto current_version = _shared_token_metadata.get()->get_topology_version();
+        if (fencing_token.topology_version == current_version) {
+            co_return std::nullopt;
+        }
+        if (fencing_token.topology_version < current_version) {
+            const auto request_info = co_await get_request_info();
+            const auto& ks_name = request_info.schema->ks_name();
+            const auto& ks = _db.local().find_keyspace(ks_name);
+            auto erm = ks.get_effective_replication_map();
+            const auto natural_endpoints = erm->get_natural_endpoints_without_node_being_replaced(request_info.token);
+            const auto pending_endpoints = erm->get_token_metadata_ptr()->pending_endpoints_for(request_info.token, ks_name);
+
+            // Check if this replica is on the list of target replicas for mutation RPC.
+            // For read RPCs, if we are reading from the replica where the mutations go, it should be fine.
+            const auto token_owned = boost::find(natural_endpoints, fbu::get_broadcast_address()) != natural_endpoints.end()
+                || boost::find(pending_endpoints, fbu::get_broadcast_address()) != pending_endpoints.end();
+            if (token_owned) {
+                co_return std::nullopt;
+            }
+            slogger.trace("Stale topology fenced, caller version {}, callee version {}",
+                fencing_token.topology_version, current_version);
+            co_return replica::stale_topology_exception(fencing_token.topology_version, current_version);
+        }
+        co_await _shared_token_metadata.wait_for_next_version(timeout);
+    }
 }
 
 }

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -30,6 +30,7 @@
 #include "db/hints/host_filter.hh"
 #include "utils/small_vector.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
+#include "service/raft_bootstrap.hh"
 #include <seastar/core/circular_buffer.hh>
 #include "exceptions/exceptions.hh"
 #include "exceptions/coordinator_result.hh"
@@ -216,6 +217,20 @@ public:
     }
 
     locator::token_metadata_ptr get_token_metadata_ptr() const noexcept;
+
+    struct request_info {
+        schema_ptr schema;
+        dht::token token;
+    };
+
+    future<std::optional<replica::stale_topology_exception>> try_apply_fence(fencing_token fencing_token,
+        lowres_clock::time_point timeout,
+        noncopyable_function<future<request_info>()>&& get_request_info);
+
+    future<std::optional<replica::stale_topology_exception>> try_apply_fence(fencing_token fencing_token,
+        lowres_clock::time_point timeout,
+        const dht::partition_range& range,
+        schema_ptr schema);
 
     query::max_result_size get_max_result_size(const query::partition_slice& slice) const;
     query::tombstone_limit get_tombstone_limit() const;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1640,7 +1640,8 @@ future<> storage_service::remove_endpoint(inet_address endpoint) {
 }
 
 future<storage_service::replacement_info>
-storage_service::prepare_replacement_info(std::unordered_set<gms::inet_address> initial_contact_nodes, const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features) {
+storage_service::prepare_replacement_info(std::unordered_set<gms::inet_address> initial_contact_nodes, const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features,
+                                          bool get_tokens) {
     if (!get_replace_address()) {
         throw std::runtime_error(format("replace_address is empty"));
     }
@@ -1672,9 +1673,12 @@ storage_service::prepare_replacement_info(std::unordered_set<gms::inet_address> 
         throw std::runtime_error(format("Cannot replace_address {} because it has left the ring, status={}", replace_address, status));
     }
 
-    auto tokens = get_tokens_for(replace_address);
-    if (tokens.empty()) {
-        throw std::runtime_error(format("Could not find tokens for {} to replace", replace_address));
+    std::unordered_set<dht::token> tokens;
+    if (get_tokens) {
+        tokens = get_tokens_for(replace_address);
+        if (tokens.empty()) {
+            throw std::runtime_error(format("Could not find tokens for {} to replace", replace_address));
+        }
     }
 
     auto dc_rack = get_dc_rack_for(replace_address);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2048,6 +2048,7 @@ future<> storage_service::decommission() {
                 // Step 5: Start to sync data
                 slogger.info("DECOMMISSIONING: unbootstrap starts");
                 ss.unbootstrap().get();
+                ss.leave_ring().get();
                 slogger.info("DECOMMISSIONING: unbootstrap done");
 
                 // Step 6: Finish
@@ -2903,7 +2904,6 @@ future<> storage_service::unbootstrap() {
         }
         slogger.debug("stream acks all received.");
     }
-    co_await leave_ring();
 }
 
 future<> storage_service::removenode_add_ranges(lw_shared_ptr<dht::range_streamer> streamer, gms::inet_address leaving_node) {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -296,7 +296,7 @@ private:
         locator::host_id host_id;
     };
     future<replacement_info> prepare_replacement_info(std::unordered_set<gms::inet_address> initial_contact_nodes,
-            const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features);
+            const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features, bool get_tokens = true);
 
     void run_replace_ops(std::unordered_set<token>& bootstrap_tokens);
     void run_bootstrap_ops(std::unordered_set<token>& bootstrap_tokens);

--- a/service/topology_change_sm.hh
+++ b/service/topology_change_sm.hh
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+ */
+
+#pragma once
+
+#include<iostream>
+#include<unordered_set>
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/core/shared_ptr.hh>
+#include "dht/token.hh"
+#include "raft/raft.hh"
+#include "utils/UUID.hh"
+#include "utils/rjson.hh"
+
+namespace service {
+
+enum class tokens_state: uint8_t {
+    write_only,
+    read_write,
+    owner
+};
+
+// state are in order coordinator thread handles them
+// lower values higher prioriy
+enum class node_state: uint8_t {
+    bootstrapping,
+    unbootstrapping,
+    removing,
+    replacing,
+    requesting,
+    normal,
+    left
+};
+
+struct replica_state {
+    node_state state;
+    seastar::sstring datacenter;
+    seastar::sstring rack;
+    seastar::sstring release_version;
+    // contains a request (joining, leaving, removing, replacing)
+    // and request's parameters to do a topology operation on the node
+    std::optional<rjson::value> topology_request;
+    struct ring_state {
+        tokens_state state;
+        std::unordered_set<dht::token> tokens;
+    };
+    std::optional<ring_state> ring;
+};
+
+// State machine that is responsible for topology change
+struct topology_change_sm {
+    using topology_type = lw_shared_ptr<std::unordered_map<raft::server_id, replica_state>>;
+    topology_type _topology = make_lw_shared<topology_type::element_type>();
+    condition_variable event;
+};
+
+inline std::ostream& operator<<(std::ostream& os, tokens_state s) {
+    switch (s) {
+        case tokens_state::write_only:
+            os << "write only";
+        break;
+        case tokens_state::read_write:
+            os << "read write";
+        break;
+        case tokens_state::owner:
+            os << "owner";
+        break;
+    }
+    return os;
+}
+
+inline std::ostream& operator<<(std::ostream& os, node_state s) {
+    switch (s) {
+        case node_state::bootstrapping:
+            os << "bootstrapping";
+        break;
+        case node_state::unbootstrapping:
+            os << "unbootstrapping";
+        break;
+        case node_state::removing:
+            os << "removing";
+        break;
+        case node_state::normal:
+            os << "normal";
+        break;
+        case node_state::left:
+            os << "left";
+        break;
+        case node_state::replacing:
+            os << "replacing";
+        break;
+        case node_state::requesting:
+            os << "requesting";
+        break;
+    }
+    return os;
+}
+
+}

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -847,7 +847,7 @@ public:
 
             service::raft_group0 group0_service{
                     abort_sources.local(), raft_gr.local(), ms.local(),
-                    gossiper.local(), qp.local(), mm.local(), feature_service.local(), sys_ks.local(), group0_client};
+                    gossiper.local(), qp.local(), mm.local(), feature_service.local(), sys_ks.local(), group0_client, ss.local()};
             auto stop_group0_service = defer([&group0_service] {
                 group0_service.abort().get();
             });


### PR DESCRIPTION
The patch introduces the concept of topology version,
an int which is incremented when the topology state
changes. It's used to catch and block with error the RPCs
which were issued based on the old topology version
when the cluster is transitioning to the new one.

The patch adds topology version handling to the storage proxy.
The main function try_apply_fence compares the version
from the RPC parameters with the current one. If the version
from the parameters is greater than the current version, we
wait for the topology update on the current node
(wait_for_next_version). If the version from the parameters is
less than the current version, and the range no longer belongs
to the current node, an exception is thrown. At the moment,
this exception causes the original request to fail, in the future
the code will be improved so that the original request is
retried on the new topology.